### PR TITLE
Detecting environment-facing (i.e. backside) cam

### DIFF
--- a/examples/js/goggle-paper.js
+++ b/examples/js/goggle-paper.js
@@ -66,20 +66,27 @@ GP.PaperTracker.prototype.init = function(options){
 
 GP.PaperTracker.prototype.postInit = function(){
   var vid = this.video;
-  navigator.getUserMedia({video:true}, 
-    function (stream){
-      if (window.webkitURL) {
-        vid.src = window.webkitURL.createObjectURL(stream);
-      } else if (vid.mozSrcObject !== undefined) {
-        vid.mozSrcObject = stream;
-      } else {
-        vid.src = stream;
+  
+  MediaStreamTrack.getSources(function(mediaSources) {
+    mediaSources.forEach(function(mediaSource){
+      if (mediaSource.kind === 'video' && mediaSource.facing == "environment") {
+	navigator.getUserMedia({video: {optional: [{sourceId: mediaSource.id}]}}, 
+          function (stream){
+      	    if (window.webkitURL) {
+              vid.src = window.webkitURL.createObjectURL(stream);
+            } else if (vid.mozSrcObject !== undefined) {
+              vid.mozSrcObject = stream;
+            } else {
+              vid.src = stream;
+            }
+          },
+          function(error){
+            console.log('stream not found');
+          }
+        );
       }
-    },
-    function(error){
-      console.log('stream not found');
-    }
-  );
+    });
+  });
 };
 
 GP.PaperTracker.prototype.snapshot = function(){


### PR DESCRIPTION
This addresses the problem explained in #1 

What it currently does is:

* it goes through the list of all sources for GetUserMedia
* it checks if a source is a camera and faces the environment (i.e. a backside camera)
* if it is, it starts capturing from this source.

I will amend it a bit, so that it is more defensive in terms of the availability of the MediaStreamTracks API and an environment-facing camera.